### PR TITLE
Replace chrono DateTime with time OffsetDateTime for formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ readme = "README.md"
 keywords = ["logger", "filter", "filter-logger" ]
 
 [dependencies]
-chrono = "0.4"
 lazy_static = "1.2"
 log = {version="0.4", features=["std"]}
+time = {version="0.3.11", features=["formatting", "macros"]}

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ of the record object passed into the `log()` function.
 
 ## Date-time Format
 
-The format can be changed by using the `with_format` function instead of `init`:
+The format can be changed by using the `with_format` function instead of `init`. \
+See [the time library book](https://time-rs.github.io/book/api/format-description.html) for format descriptions.
 
 ```rust
 extern crate filter_logger;
@@ -61,7 +62,7 @@ use filter_logger::FilterLogger;
 
 #[test]
 fn test() {
-    FilterLogger::with_format(log::Level::Info, vec![], vec![], "%Y%m%dT%H%M%S%z");
+    FilterLogger::with_format(log::Level::Info, vec![], vec![], "[year][month][day]T[hour][minute][second][offset_hour sign:mandatory][offset_minute]");
     info!("Should use RFC 3339 format!");
 }
 ```

--- a/tests/test_log.rs
+++ b/tests/test_log.rs
@@ -1,13 +1,16 @@
 extern crate filter_logger;
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate log;
 
 use filter_logger::FilterLogger;
 
 #[test]
 fn test_log() {
-    FilterLogger::init(log::Level::Info,
-                       vec!["foo2".to_string(), "foo3".to_string()],
-                       vec!["DON'T PRINT".to_string()]);
+    FilterLogger::init(
+        log::Level::Info,
+        vec!["foo2".to_string(), "foo3".to_string()],
+        vec!["DON'T PRINT".to_string()],
+    );
     foo1::log_it();
     foo2::log_it();
     foo3::log_it();
@@ -15,10 +18,12 @@ fn test_log() {
 
 #[test]
 fn test_format() {
-    FilterLogger::with_format(log::Level::Info,
-                              vec![],
-                              vec![],
-                              "%Y%m%dT%H%M%S".into());
+    FilterLogger::with_format(
+        log::Level::Info,
+        vec![],
+        vec![],
+        "[year][month][day]T[hour][minute][second]".into(),
+    );
     info!("Test logger");
 }
 


### PR DESCRIPTION
We only use DateTime for formatting here, so replacing that struct with OffsetDateTime is straightforward, although it does affect what actual strings users should provide to `FilterLogger::with_format`. Other than that all changes are just from `cargo fmt`.