### PR TITLE
Remove unnecessary chrono features to drop old time version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ readme = "README.md"
 keywords = ["logger", "filter", "filter-logger" ]
 
 [dependencies]
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 lazy_static = "1.2"
 log = {version="0.4", features=["std"]}


### PR DESCRIPTION
In order to remove a dependency on an old version of `time`, we can remove support for unnecessary `chrono` features.